### PR TITLE
Adding Keycard 3.1 support

### DIFF
--- a/Sources/Keycard/Keycard.swift
+++ b/Sources/Keycard/Keycard.swift
@@ -99,6 +99,7 @@ public enum ExportKeyP1: UInt8 {
 public enum ExportKeyP2: UInt8 {
     case privateAndPublic = 0x00
     case publicOnly = 0x01
+    case extendedPublic = 0x02
 }
 
 public enum SecureChannelINS: UInt8 {


### PR DESCRIPTION
This PR adds support for some Keycard 3.1 features:

- Extended public keys export
- Extra initialization params (PIN attempts, PUK attempts and duress PIN)